### PR TITLE
Implement client pages UI

### DIFF
--- a/actions/create-client.ts
+++ b/actions/create-client.ts
@@ -1,0 +1,63 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { headers } from "next/headers";
+import { createClient as createSupabaseClient } from "@/lib/supabase/server";
+import { rateLimit } from "@/lib/rate-limit";
+
+type State = { error?: string; success?: string } | null;
+
+export async function createClient(
+  _prevState: State,
+  formData: FormData,
+): Promise<State> {
+  const ip = (await headers()).get("x-forwarded-for") ?? "unknown";
+  const { limited } = rateLimit(`create-client:${ip}`, {
+    maxRequests: 10,
+    windowMs: 60_000,
+  });
+
+  if (limited) {
+    return { error: "Too many attempts. Please try again later." };
+  }
+
+  const name = formData.get("name");
+  const email = formData.get("email");
+  const phone = formData.get("phone");
+  const status = formData.get("status");
+  const notes = formData.get("notes");
+
+  if (typeof name !== "string" || !name.trim()) {
+    return { error: "Client name is required." };
+  }
+
+  if (name.trim().length > 100) {
+    return { error: "Client name must be 100 characters or fewer." };
+  }
+
+  const supabase = await createSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be signed in." };
+  }
+
+  const { error } = await supabase.from("clients").insert({
+    user_id: user.id,
+    name: (name as string).trim(),
+    email: (email as string) || null,
+    phone: (phone as string) || null,
+    status: (status as string) || "lead",
+    notes: (notes as string) || null,
+  });
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  revalidatePath("/clients");
+  redirect("/clients");
+}

--- a/actions/delete-client.ts
+++ b/actions/delete-client.ts
@@ -1,0 +1,42 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { headers } from "next/headers";
+import { createClient } from "@/lib/supabase/server";
+import { rateLimit } from "@/lib/rate-limit";
+
+export async function deleteClient(
+  clientId: string,
+): Promise<{ error?: string } | null> {
+  const ip = (await headers()).get("x-forwarded-for") ?? "unknown";
+  const { limited } = rateLimit(`delete-client:${ip}`, {
+    maxRequests: 5,
+    windowMs: 60_000,
+  });
+
+  if (limited) {
+    return { error: "Too many attempts. Please try again later." };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be signed in." };
+  }
+
+  const { error } = await supabase
+    .from("clients")
+    .delete()
+    .eq("id", clientId)
+    .eq("user_id", user.id);
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  revalidatePath("/clients");
+  return null;
+}

--- a/actions/update-client.ts
+++ b/actions/update-client.ts
@@ -1,0 +1,67 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { headers } from "next/headers";
+import { createClient } from "@/lib/supabase/server";
+import { rateLimit } from "@/lib/rate-limit";
+
+type State = { error?: string; success?: string } | null;
+
+export async function updateClient(
+  clientId: string,
+  _prevState: State,
+  formData: FormData,
+): Promise<State> {
+  const ip = (await headers()).get("x-forwarded-for") ?? "unknown";
+  const { limited } = rateLimit(`update-client:${ip}`, {
+    maxRequests: 10,
+    windowMs: 60_000,
+  });
+
+  if (limited) {
+    return { error: "Too many attempts. Please try again later." };
+  }
+
+  const name = formData.get("name");
+  const email = formData.get("email");
+  const phone = formData.get("phone");
+  const status = formData.get("status");
+  const notes = formData.get("notes");
+
+  if (typeof name !== "string" || !name.trim()) {
+    return { error: "Client name is required." };
+  }
+
+  if (name.trim().length > 100) {
+    return { error: "Client name must be 100 characters or fewer." };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be signed in." };
+  }
+
+  const { error } = await supabase
+    .from("clients")
+    .update({
+      name: (name as string).trim(),
+      email: (email as string) || null,
+      phone: (phone as string) || null,
+      status: (status as string) || "lead",
+      notes: (notes as string) || null,
+    })
+    .eq("id", clientId)
+    .eq("user_id", user.id);
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  revalidatePath(`/clients/${clientId}`);
+  redirect(`/clients/${clientId}`);
+}

--- a/app/clients/[id]/edit/page.tsx
+++ b/app/clients/[id]/edit/page.tsx
@@ -1,0 +1,69 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { notFound, redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { Header } from "@/components/header";
+import { ClientForm } from "@/components/client-form";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default async function EditClientPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/auth/sign-in");
+  }
+
+  const { data: client } = await supabase
+    .from("clients")
+    .select("*")
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!client) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-stone-50">
+      <Header />
+      <main className="mx-auto max-w-2xl px-4 py-10">
+        <div className="mb-6">
+          <Link
+            href={`/clients/${client.id}`}
+            className="inline-flex items-center gap-1.5 text-sm text-stone-500 hover:text-stone-800 transition-colors"
+          >
+            <ArrowLeft className="size-4" />
+            Back to client
+          </Link>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Edit Client</CardTitle>
+            <CardDescription>
+              Update the details for {client.name}.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ClientForm client={client} />
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/app/clients/[id]/page.tsx
+++ b/app/clients/[id]/page.tsx
@@ -1,0 +1,117 @@
+import Link from "next/link";
+import { ArrowLeft, Mail, Phone, StickyNote, CalendarDays, Pencil } from "lucide-react";
+import { notFound, redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { Header } from "@/components/header";
+import { StatusBadge } from "@/components/ui/status-badge";
+import { DeleteClientButton } from "@/components/delete-client-button";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default async function ClientDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/auth/sign-in");
+  }
+
+  const { data: client } = await supabase
+    .from("clients")
+    .select("*")
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!client) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-stone-50">
+      <Header />
+      <main className="mx-auto max-w-2xl px-4 py-10">
+        <div className="mb-6">
+          <Link
+            href="/clients"
+            className="inline-flex items-center gap-1.5 text-sm text-stone-500 hover:text-stone-800 transition-colors"
+          >
+            <ArrowLeft className="size-4" />
+            Back to clients
+          </Link>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-xl">{client.name}</CardTitle>
+              <StatusBadge status={client.status} />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <dl className="grid gap-4 sm:grid-cols-2">
+              <div className="flex items-start gap-2">
+                <Mail className="mt-0.5 size-3.5 shrink-0 text-stone-400" />
+                <div>
+                  <dt className="text-xs text-stone-500">Email</dt>
+                  <dd className="text-sm text-stone-800">
+                    {client.email || "—"}
+                  </dd>
+                </div>
+              </div>
+              <div className="flex items-start gap-2">
+                <Phone className="mt-0.5 size-3.5 shrink-0 text-stone-400" />
+                <div>
+                  <dt className="text-xs text-stone-500">Phone</dt>
+                  <dd className="text-sm text-stone-800">
+                    {client.phone || "—"}
+                  </dd>
+                </div>
+              </div>
+              <div className="flex items-start gap-2 sm:col-span-2">
+                <StickyNote className="mt-0.5 size-3.5 shrink-0 text-stone-400" />
+                <div>
+                  <dt className="text-xs text-stone-500">Notes</dt>
+                  <dd className="whitespace-pre-wrap text-sm text-stone-800">
+                    {client.notes || "—"}
+                  </dd>
+                </div>
+              </div>
+              <div className="flex items-start gap-2">
+                <CalendarDays className="mt-0.5 size-3.5 shrink-0 text-stone-400" />
+                <div>
+                  <dt className="text-xs text-stone-500">Created</dt>
+                  <dd className="text-sm text-stone-800">
+                    {new Date(client.created_at).toLocaleDateString()}
+                  </dd>
+                </div>
+              </div>
+            </dl>
+          </CardContent>
+        </Card>
+
+        <div className="mt-6 flex items-center justify-between">
+          <Link href={`/clients/${client.id}/edit`}>
+            <Button variant="secondary" className="w-auto px-4 inline-flex items-center gap-1.5">
+              <Pencil className="size-3.5" />
+              Edit Client
+            </Button>
+          </Link>
+          <DeleteClientButton clientId={client.id} />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/clients/new/page.tsx
+++ b/app/clients/new/page.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { Header } from "@/components/header";
+import { ClientForm } from "@/components/client-form";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default async function NewClientPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/auth/sign-in");
+  }
+
+  return (
+    <div className="min-h-screen bg-stone-50">
+      <Header />
+      <main className="mx-auto max-w-2xl px-4 py-10">
+        <div className="mb-6">
+          <Link
+            href="/clients"
+            className="inline-flex items-center gap-1.5 text-sm text-stone-500 hover:text-stone-800 transition-colors"
+          >
+            <ArrowLeft className="size-4" />
+            Back to clients
+          </Link>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>New Client</CardTitle>
+            <CardDescription>
+              Add a new client to your account.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ClientForm />
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -1,0 +1,82 @@
+import Link from "next/link";
+import { Plus, Users } from "lucide-react";
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { Header } from "@/components/header";
+import { ClientCard } from "@/components/client-card";
+import { ClientsFilter } from "@/components/clients-filter";
+import { Button } from "@/components/ui/button";
+
+export default async function ClientsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ search?: string; status?: string }>;
+}) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/auth/sign-in");
+  }
+
+  const { search, status } = await searchParams;
+
+  let query = supabase
+    .from("clients")
+    .select("*")
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: false });
+
+  if (search) {
+    query = query.ilike("name", `%${search}%`);
+  }
+
+  if (status) {
+    query = query.eq("status", status);
+  }
+
+  const { data: clients } = await query;
+
+  return (
+    <div className="min-h-screen bg-stone-50">
+      <Header />
+      <main className="mx-auto max-w-5xl px-4 py-10">
+        <div className="mb-6 flex items-center justify-between">
+          <h1 className="text-2xl font-semibold text-stone-800">Clients</h1>
+          <Link href="/clients/new">
+            <Button className="w-auto px-4 inline-flex items-center gap-1.5">
+              <Plus className="size-4" />
+              Add Client
+            </Button>
+          </Link>
+        </div>
+
+        <div className="mb-6">
+          <ClientsFilter />
+        </div>
+
+        {clients && clients.length > 0 ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {clients.map((client) => (
+              <ClientCard key={client.id} client={client} />
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center rounded-xl border bg-white py-16">
+            <Users className="size-10 text-stone-300" />
+            <p className="mt-3 text-sm text-stone-500">No clients found.</p>
+            <Link
+              href="/clients/new"
+              className="mt-2 inline-flex items-center gap-1 text-sm font-medium text-blue-500 hover:text-blue-600"
+            >
+              <Plus className="size-3.5" />
+              Add your first client
+            </Link>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/components/client-card.tsx
+++ b/components/client-card.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { Mail, Phone } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { StatusBadge, type ClientStatus } from "@/components/ui/status-badge";
+
+export type Client = {
+  id: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  status: ClientStatus;
+  notes: string | null;
+  created_at: string;
+};
+
+export function ClientCard({ client }: { client: Client }) {
+  return (
+    <Link href={`/clients/${client.id}`} className="block">
+      <Card className="transition-shadow hover:shadow-md">
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-base">{client.name}</CardTitle>
+            <StatusBadge status={client.status} />
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col gap-1.5 text-sm text-stone-500">
+            {client.email && (
+              <p className="flex items-center gap-1.5">
+                <Mail className="size-3.5 text-stone-400" />
+                {client.email}
+              </p>
+            )}
+            {client.phone && (
+              <p className="flex items-center gap-1.5">
+                <Phone className="size-3.5 text-stone-400" />
+                {client.phone}
+              </p>
+            )}
+            {!client.email && !client.phone && (
+              <p className="italic">No contact info</p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/components/client-form.tsx
+++ b/components/client-form.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useActionState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { createClient } from "@/actions/create-client";
+import { updateClient } from "@/actions/update-client";
+import type { Client } from "@/components/client-card";
+
+const statuses = [
+  { label: "Lead", value: "lead" },
+  { label: "Active", value: "active" },
+  { label: "Archived", value: "archived" },
+];
+
+export function ClientForm({ client }: { client?: Client }) {
+  const action = client
+    ? updateClient.bind(null, client.id)
+    : createClient;
+
+  const [state, formAction, pending] = useActionState(action, null);
+
+  return (
+    <form action={formAction} className="flex flex-col gap-4">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Input
+          label="Name"
+          id="name"
+          name="name"
+          type="text"
+          required
+          defaultValue={client?.name ?? ""}
+          placeholder="Client name..."
+        />
+
+        <Input
+          label="Email"
+          id="email"
+          name="email"
+          type="email"
+          defaultValue={client?.email ?? ""}
+          placeholder="client@example.com"
+        />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Input
+          label="Phone"
+          id="phone"
+          name="phone"
+          type="tel"
+          defaultValue={client?.phone ?? ""}
+          placeholder="+1 (555) 000-0000"
+        />
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="status" className="text-xs text-stone-500">
+            Status
+          </label>
+          <select
+            id="status"
+            name="status"
+            defaultValue={client?.status ?? "lead"}
+            className="h-9 w-full rounded-md border border-stone-200 bg-stone-100 px-2.5 text-sm text-stone-800 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 transition-colors"
+          >
+            {statuses.map((s) => (
+              <option key={s.value} value={s.value}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="notes" className="text-xs text-stone-500">
+          Notes
+        </label>
+        <textarea
+          id="notes"
+          name="notes"
+          rows={4}
+          defaultValue={client?.notes ?? ""}
+          placeholder="Any notes about this client..."
+          className="w-full rounded-md border border-stone-200 bg-stone-100 px-2.5 py-2 text-sm text-stone-800 placeholder:text-stone-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 transition-colors"
+        />
+      </div>
+
+      {state?.error && (
+        <div
+          role="alert"
+          className="rounded-lg border border-red-200 bg-red-50 px-3 py-2"
+        >
+          <p className="text-sm text-red-700">{state.error}</p>
+        </div>
+      )}
+
+      {state?.success && (
+        <div
+          role="status"
+          className="rounded-lg border border-green-200 bg-green-50 px-3 py-2"
+        >
+          <p className="text-sm text-green-800">{state.success}</p>
+        </div>
+      )}
+
+      <div>
+        <Button type="submit" disabled={pending} className="w-auto px-6">
+          {pending
+            ? "Saving..."
+            : client
+              ? "Save changes"
+              : "Create client"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/components/clients-filter.tsx
+++ b/components/clients-filter.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+
+const statuses = [
+  { label: "All Statuses", value: "" },
+  { label: "Lead", value: "lead" },
+  { label: "Active", value: "active" },
+  { label: "Archived", value: "archived" },
+];
+
+export function ClientsFilter() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const currentSearch = searchParams.get("search") ?? "";
+  const currentStatus = searchParams.get("status") ?? "";
+
+  function updateParams(key: string, value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value) {
+      params.set(key, value);
+    } else {
+      params.delete(key);
+    }
+    router.push(`/clients?${params.toString()}`);
+  }
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row">
+      <div className="relative flex-1">
+        <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-stone-400" />
+        <Input
+          placeholder="Search clients..."
+          defaultValue={currentSearch}
+          onChange={(e) => updateParams("search", e.target.value)}
+          className="pl-8"
+        />
+      </div>
+      <select
+        value={currentStatus}
+        onChange={(e) => updateParams("status", e.target.value)}
+        className="h-9 rounded-md border border-stone-200 bg-stone-100 px-2.5 text-sm text-stone-800 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 transition-colors"
+      >
+        {statuses.map((s) => (
+          <option key={s.value} value={s.value}>
+            {s.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/components/delete-client-button.tsx
+++ b/components/delete-client-button.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { deleteClient } from "@/actions/delete-client";
+
+export function DeleteClientButton({ clientId }: { clientId: string }) {
+  const [confirming, setConfirming] = useState(false);
+  const [pending, setPending] = useState(false);
+  const router = useRouter();
+
+  async function handleDelete() {
+    setPending(true);
+    const result = await deleteClient(clientId);
+    setPending(false);
+
+    if (result?.error) {
+      alert(result.error);
+      setConfirming(false);
+      return;
+    }
+
+    router.push("/clients");
+  }
+
+  if (!confirming) {
+    return (
+      <Button
+        variant="secondary"
+        className="w-auto border-red-200 px-4 text-red-600 hover:bg-red-50 inline-flex items-center gap-1.5"
+        onClick={() => setConfirming(true)}
+      >
+        <Trash2 className="size-3.5" />
+        Delete
+      </Button>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-sm text-stone-500">Are you sure?</span>
+      <Button
+        variant="secondary"
+        className="w-auto border-red-200 px-4 text-red-600 hover:bg-red-50"
+        onClick={handleDelete}
+        disabled={pending}
+      >
+        {pending ? "Deleting..." : "Yes, delete"}
+      </Button>
+      <Button
+        variant="secondary"
+        className="w-auto px-4"
+        onClick={() => setConfirming(false)}
+      >
+        Cancel
+      </Button>
+    </div>
+  );
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -18,6 +18,12 @@ export async function Header() {
           {user ? (
             <>
               <Link
+                href="/clients"
+                className="text-sm font-medium text-stone-600 hover:text-stone-800 transition-colors"
+              >
+                Clients
+              </Link>
+              <Link
                 href="/profile"
                 className="text-sm font-medium text-stone-600 hover:text-stone-800 transition-colors"
               >

--- a/components/ui/status-badge.tsx
+++ b/components/ui/status-badge.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils";
+
+const statusStyles = {
+  lead: "bg-stone-100 text-stone-700 border-stone-200",
+  active: "bg-green-50 text-green-700 border-green-200",
+  archived: "bg-yellow-50 text-yellow-700 border-yellow-200",
+} as const;
+
+export type ClientStatus = "lead" | "active" | "archived";
+
+export function StatusBadge({ status }: { status: ClientStatus }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium capitalize",
+        statusStyles[status],
+      )}
+    >
+      {status}
+    </span>
+  );
+}


### PR DESCRIPTION
 - Add full clients CRUD UI: list page with search/filter, create form, detail view, and edit form                                                                 
  - Add reusable `StatusBadge` component (Lead=gray, Active=green, Archived=yellow) and `ClientCard` with contact info icons
  - Add server actions for create, update, and delete with validation and rate limiting                                                                             
  - Add "Clients" link to header navigation for authenticated users                                                                                                 
  - Uses Lucide icons throughout (ArrowLeft, Plus, Search, Mail, Phone, Trash2, Pencil, etc.)                                                                       
                                                                                                   